### PR TITLE
make sure cron entries work

### DIFF
--- a/docker/cron-cloudlog
+++ b/docker/cron-cloudlog
@@ -1,3 +1,3 @@
-@weekly curl --silent http://localhost/index.php/lotw/load_users &>/dev/null
-@weekly curl --silent http://localhost/index.php/update/dxcc &>/dev/null
-@weekly curl --silent http://localhost/index.php/update/update_clublog_scp &>/dev/null
+@weekly curl --silent http://web/index.php/lotw/load_users &>/dev/null
+@weekly curl --silent http://web/index.php/update/dxcc &>/dev/null
+@weekly curl --silent http://web/index.php/update/update_clublog_scp &>/dev/null


### PR DESCRIPTION
"localhost" in the cron container doesn't resolve to the instance running the web service, which is launched under service "web". By changing these entries, the cron entries will work.